### PR TITLE
feat: add configurable initial Vim mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Configure the plugin in `tui.json`:
 | Option                          | Purpose                                       |
 | ------------------------------- | --------------------------------------------- |
 | `enabled`                       | Start with Vim mode enabled                   |
+| `initial_mode`                  | Start in `normal` (default) or `insert` mode  |
+| `vim_initial_mode`              | Alias for `initial_mode`                      |
 | `toggle_key`                    | Keybind for `Toggle vim mode`                 |
 | `indicator`                     | Show the prompt Vim indicator                 |
 | `enter_submit`                  | Submit with Enter from insert mode            |
@@ -104,6 +106,24 @@ Configure the plugin in `tui.json`:
 
 > [!NOTE]
 > Unsupported ocv options: `vim_line_motions`, `vim_escape_sequence`.
+
+### Initial mode
+
+Vim mode starts in normal mode by default. To start with Vim mode enabled and the prompt ready for typing, use:
+
+```json
+{
+  "plugin": [
+    [
+      "@leohenon/opencode-vim-plugin",
+      {
+        "enabled": true,
+        "vim_initial_mode": "insert"
+      }
+    ]
+  ]
+}
+```
 
 ### Mode-scoped keybinds
 

--- a/script/check-adapter.ts
+++ b/script/check-adapter.ts
@@ -176,6 +176,18 @@ async function setup(options: unknown = {}) {
 }
 
 {
+  const { layers, api } = await setup({
+    enabled: true,
+    vim_initial_mode: "insert",
+    normal_keybinds: { q: "session.list" },
+  })
+  const normalLayer = layers.find((layer) => layer.priority === 200)
+  assert(normalLayer, "normal-mode keybind layer was not registered")
+  api.renderer.currentFocusedEditor = fakeTextarea()
+  assert(normalLayer.enabled() === false, "vim_initial_mode insert should start Vim in insert mode")
+}
+
+{
   const { layers, api, dispatched, disposers } = await setup()
   const commandLayer = layers.find((layer) => layer.commands?.some((command: any) => command.name === "ocv-plugin.toggle"))
   assert(commandLayer?.mode === undefined, "vim palette commands should remain reachable while autocomplete is open")

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -12,9 +12,11 @@ const KV_ENABLED = "ocv-plugin.enabled"
 const NORMAL_LEADER_TOKEN = "ocv-plugin-leader"
 
 type NormalBinding = Binding<Renderable, KeyEvent> & { cmd: string }
+type InitialMode = "normal" | "insert"
 
 type Options = {
   enabled: boolean
+  initialMode?: InitialMode
   toggleKey?: string
   indicator: boolean
   enterSubmit: boolean
@@ -31,6 +33,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function nonEmptyString(value: unknown) {
   return typeof value === "string" && value.trim() ? value : undefined
+}
+
+function readInitialMode(value: unknown): InitialMode | undefined {
+  return value === "normal" || value === "insert" ? value : undefined
 }
 
 // Mirrors OpenCode TUI's CommandMap for OCV-style keybind compatibility.
@@ -257,6 +263,7 @@ function readNormalBindings(options: Record<string, unknown>, normalLeader: stri
 function readOptions(input: unknown): Options {
   const options = isRecord(input) ? input : {}
   const enabled = typeof options.enabled === "boolean" ? options.enabled : true
+  const initialMode = readInitialMode(options.initial_mode) ?? readInitialMode(options.vim_initial_mode)
   const toggleKey = nonEmptyString(options.toggle_key)
   const indicator = options.indicator === false || options.indicator === "off" ? false : true
   const enterSubmit = options.enter_submit === true || options.vim_enter_submit === true
@@ -275,6 +282,7 @@ function readOptions(input: unknown): Options {
   const normalLeader = nonEmptyString(options.normal_leader) ?? nonEmptyString(options.vim_normal_leader) ?? nonEmptyString(keybinds?.leader)
   return {
     enabled,
+    initialMode,
     toggleKey,
     indicator,
     enterSubmit,
@@ -322,7 +330,7 @@ const tui: TuiPlugin = async (api, rawOptions) => {
   const [enabled, setEnabled] = createSignal(initialEnabled)
   const prompt = createPromptVim(api, {
     enabled,
-    initialMode: initialEnabled ? "normal" : "insert",
+    initialMode: initialEnabled ? (options.initialMode ?? "normal") : "insert",
     enterSubmit: options.enterSubmit,
     insertAfterSubmit: options.insertAfterSubmit,
     systemClipboardRegister: options.systemClipboardRegister,


### PR DESCRIPTION
Adds a startup-mode setting so users can load the plugin directly into prompt editing rather than normal mode. `initial_mode` accepts `normal` or `insert`, with a `vim_initial_mode` alias; the existing normal-mode default is unchanged.