### PR TITLE
fix: refresh prompt layout after paste

### DIFF
--- a/script/check-adapter.ts
+++ b/script/check-adapter.ts
@@ -579,6 +579,45 @@ async function setup(options: unknown = { initial_mode: "normal" }) {
 }
 
 {
+  const { layers, api } = await setup()
+  const commandLayer = layers.find((layer) => layer.commands?.some((command: any) => command.name === "ocv-plugin.key"))
+  const key = commandLayer.commands.find((command: any) => command.name === "ocv-plugin.key")
+  const editor: any = fakeTextarea()
+  const stats = { layoutRefreshes: 0, renderRequests: 0 }
+  const layoutRefreshes = () => stats.layoutRefreshes
+  const renderRequests = () => stats.renderRequests
+  let resolveHostPaste: (() => void) | undefined
+  editor.getLayoutNode = () => ({ markDirty: () => stats.layoutRefreshes++ })
+  editor.onPaste = () =>
+    new Promise<void>((resolve) => {
+      resolveHostPaste = resolve
+    })
+  api.renderer.currentFocusedEditor = editor
+  api.renderer.requestRender = () => stats.renderRequests++
+  const keyEvent = (name: string) => ({
+    name,
+    sequence: name,
+    raw: name,
+    ctrl: false,
+    meta: false,
+    super: false,
+    shift: false,
+    preventDefault() {},
+    stopPropagation() {},
+  })
+
+  key.run({ event: keyEvent("i") })
+  editor.onPaste({ preventDefault() {}, stopPropagation() {} })
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  assert(layoutRefreshes() === 0, "paste layout refresh should wait for the host paste handler")
+  resolveHostPaste?.()
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  assert(layoutRefreshes() === 1, "completed pastes should refresh the prompt layout")
+  assert(renderRequests() === 1, "completed pastes should request a render after refreshing the prompt layout")
+}
+
+{
   const { layers, api } = await setup({ initial_mode: "normal", vim_langmap: { р: "h" } })
   const commandLayer = layers.find((layer) => layer.commands?.some((command: any) => command.name === "ocv-plugin.key"))
   const bindingLayer = layers.find((layer) => layer.priority === 100)

--- a/src/prompt-vim.ts
+++ b/src/prompt-vim.ts
@@ -368,6 +368,17 @@ export function createPromptVim(
   }
 
   const patchedEditors = new Set<TextareaLike>()
+  const pasteLayoutTimers = new Set<ReturnType<typeof setTimeout>>()
+
+  function refreshPasteLayout(editor: TextareaLike) {
+    const timer = setTimeout(() => {
+      pasteLayoutTimers.delete(timer)
+      if (editor.isDestroyed) return
+      editor.getLayoutNode().markDirty()
+      api.renderer.requestRender()
+    }, 0)
+    pasteLayoutTimers.add(timer)
+  }
 
   function prunePatchedEditors() {
     for (const patched of patchedEditors) {
@@ -416,7 +427,15 @@ export function createPromptVim(
         event.stopPropagation()
         return
       }
-      return originalPaste?.call(editor, event)
+      const result = originalPaste?.call(editor, event) as unknown
+      if (typeof (result as PromiseLike<unknown> | undefined)?.then === "function") {
+        void Promise.resolve(result).then(
+          () => refreshPasteLayout(editor),
+          () => refreshPasteLayout(editor),
+        )
+      } else {
+        refreshPasteLayout(editor)
+      }
     }
     editor[PROMPT_RENDER_PATCH] = {
       original,
@@ -691,6 +710,8 @@ export function createPromptVim(
   function dispose() {
     handler.cancelPending()
     state.cancelEdit()
+    for (const timer of pasteLayoutTimers) clearTimeout(timer)
+    pasteLayoutTimers.clear()
     if (flashTimer) {
       clearTimeout(flashTimer)
       flashTimer = undefined


### PR DESCRIPTION
Async host paste handlers can finish after the prompt layout/render pass, leaving pasted text visually stale until another UI event. Defer a layout refresh until the paste handler settles, and cancel pending refresh timers during disposal. Adds adapter coverage for async paste completion.