### PR TITLE
Support vim_escape_sequence in plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ For options beginning with `vim_`, the prefix may be omitted in plugin configura
 | `vim_normal_leader`             | Leader key for normal keybinds                |
 | `normal_keybinds`               | Extra keybinds active only in Vim normal mode |
 | `keybinds["vim.normal"]`        | Nested normal-mode keybind configuration      |
+| vim_escape_sequence             | Use a two-key escape sequence like jk         |
 
 > [!NOTE]
-> Unsupported OCV options: `vim_line_motions`, `vim_escape_sequence`.
+> Unsupported OCV options: `vim_line_motions`
 
 ### Initial mode
 
@@ -296,6 +297,16 @@ Or for simple aliases:
       }
     ]
   ]
+}
+```
+
+### Vim escape sequence
+
+Set a two-character sequence to leave insert mode without pressing Escape:
+
+```json
+{
+  "vim_escape_sequence": "jk"
 }
 ```
 

--- a/src/prompt-vim.ts
+++ b/src/prompt-vim.ts
@@ -341,6 +341,7 @@ export function createPromptVim(
     insertAfterSubmit?: boolean
     systemClipboardRegister?: boolean
     langmap?: () => Record<string, string> | undefined
+    vimEscapeSequence?: string
   },
 ) {
   let lastPromptEditor: TextareaLike | undefined
@@ -638,6 +639,7 @@ export function createPromptVim(
     copySearchStart: () => false,
     autocomplete: () => false,
     langmap: input.langmap,
+    vimEscapeSequence: input.vimEscapeSequence,
   })
 
   onPromptEditorChange = (previous) => {

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -23,6 +23,7 @@ type Options = {
   insertAfterSubmit: boolean
   systemClipboardRegister: boolean
   langmap?: Record<string, string>
+  vimEscapeSequence?: string
   normalLeader?: string
   normalBindings: NormalBinding[]
 }
@@ -278,6 +279,8 @@ function readOptions(input: unknown): Options {
         ),
       )
     : undefined
+  const escapeSequenceInput = nonEmptyString(options.escape_sequence) ?? nonEmptyString(options.vim_escape_sequence)
+  const vimEscapeSequence = escapeSequenceInput?.length === 2 ? escapeSequenceInput : undefined
   const keybinds = isRecord(options.keybinds) && isRecord(options.keybinds["vim.normal"]) ? options.keybinds["vim.normal"] : undefined
   const normalLeader = nonEmptyString(options.normal_leader) ?? nonEmptyString(options.vim_normal_leader) ?? nonEmptyString(keybinds?.leader)
   return {
@@ -289,6 +292,7 @@ function readOptions(input: unknown): Options {
     insertAfterSubmit,
     systemClipboardRegister,
     langmap,
+    vimEscapeSequence,
     normalLeader,
     normalBindings: readNormalBindings(options, normalLeader),
   }
@@ -335,6 +339,7 @@ const tui: TuiPlugin = async (api, rawOptions) => {
     insertAfterSubmit: options.insertAfterSubmit,
     systemClipboardRegister: options.systemClipboardRegister,
     langmap: () => options.langmap,
+    vimEscapeSequence: options.vimEscapeSequence,
   })
   api.lifecycle.onDispose(prompt.dispose)
 


### PR DESCRIPTION
### Problem

`src/vim/handler.ts` already implements two-key escape sequences — pending-key tracking, 300ms timeout, modifier guards, and retraction of the typed first character. It reads `input.vimEscapeSequence`, which was never populated.

### Changes

This wires it through:

- `src/tui.tsx` — add to `Options`, parse `escape_sequence` /   `vim_escape_sequence` (2-char strings only), include in the return, pass to  `createPromptVim()`
- `src/prompt-vim.ts` — add to the input type, forward to `createVimHandler()`

- Also drops `vim_escape_sequence` from the "Unsupported OCV options" note and documents it in the options table.

```json
{ "vim_escape_sequence": "jk" }
```

Tested locally w/ latest opencode.

### How to test

1. `cd ~/.config/opencode`
2. `git clone -b add-vim-escape-sequence-support git@github.com:erzhtor/opencode-vim-plugin.git`
3. `bun install && bun run check && bun run build`
4. Update opencode's `tui.json`
```json
{
  "$schema": "https://opencode.ai/tui.json",
  "plugin": [
    [
      "/Users/erzhan/.config/opencode/plugins/opencode-vim-plugin",
      { "vim_escape_sequence": "jk" }
    ]
  ]
}

```